### PR TITLE
Put conditional #+sbcl on references to SB-EXT

### DIFF
--- a/wxmx2texi/wcatchable_syntax_error.lisp
+++ b/wxmx2texi/wcatchable_syntax_error.lisp
@@ -5,7 +5,7 @@
 
 ;; Helper for MREAD-SYNERR.
 ;; Adapted from local function PRINTER in built-in MREAD-SYNERR.
-(declaim (sb-ext:muffle-conditions cl:warning))
+#+sbcl (declaim (sb-ext:muffle-conditions cl:warning))
 
 
 (defun mread-synerr-printer (x)

--- a/wxmx2texi/wmathml.lisp
+++ b/wxmx2texi/wmathml.lisp
@@ -1,6 +1,6 @@
 ;;This a a modified version of the pacakge mathml.lisp
 
-(declaim (sb-ext:muffle-conditions cl:warning))
+#+sbcl (declaim (sb-ext:muffle-conditions cl:warning))
 
 
 (in-package :maxima)

--- a/wxmx2texi/wxmx2texi.lisp
+++ b/wxmx2texi/wxmx2texi.lisp
@@ -1,4 +1,4 @@
-(declaim (sb-ext:muffle-conditions cl:warning))
+#+sbcl (declaim (sb-ext:muffle-conditions cl:warning))
 (in-package :maxima)
 ;;plump xml parser has been used https://shinmera.github.io/plump/ 
 


### PR DESCRIPTION
Put conditional #+sbcl on references to SB-EXT, since that is specific to SBCL and it will cause an error with other Lisp implementations.
